### PR TITLE
Fix Parse Title 

### DIFF
--- a/library.js
+++ b/library.js
@@ -210,14 +210,12 @@ plugin.getUsers = function(callback) {
 	], callback);
 };
 
-plugin.updateTitle = function(data, callback) {
-	translator.translate('[[2factor:title]]', function(title) {
-		if (data.fragment.match(/^user\/.+\/2factor/)) {
-			data.parsed = title;
+plugin.updateTitle = function (data, callback) {
+	translator.translate('[[2factor:title]]', function (title) {
+		if (data.templateData.url.match(/user\/.+\/2factor/)) {
+			data.templateData.title = title;
 		}
-
 		callback(null, data);
 	});
 };
-
 module.exports = plugin;

--- a/plugin.json
+++ b/plugin.json
@@ -8,7 +8,7 @@
 		{ "hook": "filter:user.profileMenu", "method": "addProfileItem" },
 		{ "hook": "filter:router.page", "method": "check" },
 		{ "hook": "static:user.loggedOut", "method": "clearSession" },
-		{ "hook": "filter:parse.title", "method": "updateTitle" }
+		{ "hook": "filter:middleware.render", "method": "updateTitle" }
 	],
 	"staticDirs": {
 		"static": "./static"


### PR DESCRIPTION
`filter:parse.title` is not work in NodeBB 1.5.2. I think use this way can support most of version.
## Screenshot
![raNW3.png](https://piccdn.freejishu.com/images/2017/08/01/raNW3.png)
![ra5YY.png](https://piccdn.freejishu.com/images/2017/08/01/ra5YY.png)
This does not seem to work.(Use `filter:parse.title`)