### PR TITLE
Fix duplicate URI escape

### DIFF
--- a/websockets.js
+++ b/websockets.js
@@ -24,7 +24,7 @@ Sockets.regenerate = function (socket, data, callback) {
 		}
 
 		const baseUrl = nconf.get('url').replace(/.*?:\/\//g, '');
-		const issuer = encodeURIComponent(meta.config.title.replace(/\s/, '%20')).replace('+', '%20');
+		const issuer = encodeURIComponent(meta.config.title).replace('+', '%20');
 		const account = encodeURIComponent(userslug + '@' + baseUrl).replace('+', '%20');
 		const otpUrl = 'otpauth://totp/' + issuer + ':' + account + '?issuer=' + issuer + '&secret=' + encodedKey.replace('+', '%20') + '&period=30';
 		qrcode.toDataURL(otpUrl, function (err, qrImage) {


### PR DESCRIPTION
Some Time ago when I adopted 2FA for our forum I noticed that it was listed as "TripleA%20Forum" instead of "TripleA Forum".
the `replace(/\s/, '%20')` part replaces all spaces with `%20` which is then encoded by `encodeURIComponent` to `%2520`, so that is being removed